### PR TITLE
Add LiteLLM provider support

### DIFF
--- a/src/ExecutionEngine.test.ts
+++ b/src/ExecutionEngine.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateExecutionPlan, executeFlow } from './ExecutionEngine';
+
+vi.mock('./nodeExecutors/NodeExecutorRegistry', () => ({
+  getNodeExecutor: () => undefined
+}));
+
+const mockClient = vi.fn();
+vi.mock('./utils/OllamaClient', () => ({
+  OllamaClient: vi.fn().mockImplementation((baseUrl: string, config: any) => {
+    mockClient(baseUrl, config);
+    return {
+      listModels: vi.fn(),
+      sendChat: vi.fn(),
+      streamChat: vi.fn()
+    };
+  })
+}));
+
+describe('ExecutionEngine litellm support', () => {
+  it('uses litellm config when apiType is litellm', async () => {
+    const nodes = [
+      {
+        id: '1',
+        type: 'baseLlmNode',
+        data: { config: { apiType: 'litellm', litellmUrl: 'http://litellm.local' } }
+      }
+    ] as any;
+
+    const plan = generateExecutionPlan(nodes, []);
+    expect(plan.config.type).toBe('litellm');
+    expect(plan.config.baseUrl).toBe('http://litellm.local');
+
+    await executeFlow(plan);
+    expect(mockClient).toHaveBeenCalledWith('http://litellm.local', { type: 'litellm', baseUrl: 'http://litellm.local' });
+  });
+});

--- a/src/ExecutionEngine.ts
+++ b/src/ExecutionEngine.ts
@@ -10,7 +10,7 @@ export interface ExecutionPlan {
   nodes: Node[];
   edges: Edge[];
   config: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };
@@ -32,7 +32,7 @@ export interface ExecutionContext {
   updateUi?: (type: string, nodeId: string, data: any) => void;
   updateNodeStatus?: (nodeId: string, status: 'running' | 'completed' | 'error') => void;
   apiConfig: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };
@@ -87,8 +87,11 @@ export function generateExecutionPlan(nodes: Node[], edges: Edge[]): ExecutionPl
       config.baseUrl = nodeConfig.openaiUrl || DEFAULT_LOCALHOST_URL;
       config.type = 'openai';
       config.apiKey = nodeConfig.apiKey;
+    } else if (nodeConfig?.apiType == 'litellm') {
+      config.baseUrl = nodeConfig.litellmUrl || DEFAULT_LOCALHOST_URL;
+      config.type = 'litellm';
     }
-  } 
+  }
 
   return { nodes, edges, config };
 }

--- a/src/components/assistant_components/AssistantSettings.tsx
+++ b/src/components/assistant_components/AssistantSettings.tsx
@@ -35,7 +35,7 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showPullModal, setShowPullModal] = useState(false);
-  const [apiType, setApiType] = useState<'ollama' | 'openai'>('ollama');
+  const [apiType, setApiType] = useState<'ollama' | 'openai' | 'litellm'>('ollama');
   const [systemPrompt, setSystemPrompt] = useState<string>('');
   const [isSavingPrompt, setIsSavingPrompt] = useState(false);
   const [isUsingDefault, setIsUsingDefault] = useState(true);
@@ -149,12 +149,13 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
             api_type: config.api_type || 'ollama',
             openai_api_key: config.openai_api_key,
             openai_base_url: config.openai_base_url || 'https://api.openai.com/v1',
+            litellm_base_url: config.litellm_base_url || 'http://localhost:4000',
             openrouter_api_key: config.openrouter_api_key,
             n8n_base_url: config.n8n_base_url,
             n8n_api_key: config.n8n_api_key
           };
           setApiConfig(configWithDefaults);
-          setApiType(configWithDefaults.api_type as 'ollama' | 'openai');
+          setApiType(configWithDefaults.api_type as 'ollama' | 'openai' | 'litellm');
         }
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred';
@@ -210,7 +211,7 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
     }
   };
 
-  const handleApiTypeChange = async (type: 'ollama' | 'openai') => {
+  const handleApiTypeChange = async (type: 'ollama' | 'openai' | 'litellm') => {
     if (apiConfig) {
       const updatedConfig: APIConfig = {
         ...apiConfig,
@@ -349,6 +350,19 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Compatible with OpenAI API format</p>
                 </div>
               </button>
+              <button
+                onClick={() => handleApiTypeChange('litellm')}
+                className={`flex flex-col items-center p-4 rounded-lg border-2 transition-all ${
+                  apiType === 'litellm'
+                    ? 'border-sakura-500 bg-sakura-50 dark:bg-sakura-500/10'
+                    : 'border-gray-200 hover:border-sakura-200 dark:border-gray-700'
+                }`}
+              >
+                <div className="text-center">
+                  <h3 className="font-medium text-gray-900 dark:text-white">LiteLLM</h3>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Self-hosted LiteLLM server</p>
+                </div>
+              </button>
             </div>
             
             {apiType === 'ollama' && (
@@ -395,6 +409,21 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
                     Default: https://api.openai.com/v1. Change this if you're using a different OpenAI-compatible API endpoint.
                   </p>
                 </div>
+              </div>
+            )}
+
+            {apiType === 'litellm' && (
+              <div className="mt-4">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  LiteLLM Base URL
+                </label>
+                <input
+                  type="url"
+                  value={apiConfig?.litellm_base_url || 'http://localhost:4000'}
+                  onChange={(e) => handleOpenAIBaseUrlChange(e.target.value)}
+                  className="w-full px-4 py-2 rounded-lg bg-white/50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white text-sm"
+                  placeholder="http://localhost:4000"
+                />
               </div>
             )}
           </div>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -65,8 +65,9 @@ export interface APIConfig {
   comfyui_base_url: string;
   openai_api_key ?: string;
   openai_base_url ?: string;
+  litellm_base_url?: string;
   openrouter_api_key ?: string;
-  api_type ?: string;
+  api_type ?: 'ollama' | 'openai' | 'litellm';
   n8n_base_url?: string;  // URL of the n8n instance
   n8n_api_key?: string;   // API Key for n8n
 }

--- a/src/nodeExecutors/NodeExecutorRegistry.tsx
+++ b/src/nodeExecutors/NodeExecutorRegistry.tsx
@@ -7,7 +7,7 @@ export interface NodeExecutionContext {
   inputs: { [key: string]: any };
   ollamaClient: OllamaClient;
   apiConfig: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/utils/OllamaClient.ts
+++ b/src/utils/OllamaClient.ts
@@ -17,7 +17,7 @@ export interface RequestOptions {
 export interface OpenAIConfig {
   apiKey: string;
   baseUrl: string;
-  type: 'ollama' | 'openai';
+  type: 'ollama' | 'openai' | 'litellm';
 }
 
 interface APIResponse {
@@ -108,7 +108,7 @@ export class OllamaClient {
       'Content-Type': 'application/json'
     };
 
-    if (this.config.type === 'openai' && this.config.apiKey) {
+    if (this.config.type !== 'ollama' && this.config.apiKey) {
       headers['Authorization'] = `Bearer ${this.config.apiKey}`;
     }
 
@@ -143,8 +143,8 @@ export class OllamaClient {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json'
       };
-      
-      if (this.config.type === 'openai' && this.config.apiKey) {
+
+      if (this.config.type !== 'ollama' && this.config.apiKey) {
         headers['Authorization'] = `Bearer ${this.config.apiKey}`;
       }
       
@@ -880,7 +880,7 @@ Your response MUST be a valid JSON object, properly formatted and parsable.`;
   }
 
   private formatTool(tool: BaseTool): OpenAITool | OllamaTool {
-    if (this.config.type === 'openai') {
+    if (this.config.type !== 'ollama') {
       return {
         type: 'function',
         ...tool
@@ -911,7 +911,7 @@ Your response MUST be a valid JSON object, properly formatted and parsable.`;
 
   // Add a new method specifically for tool calls that preserves OpenAI response format
   async sendChatWithToolsPreserveFormat(model: string, messages: ChatMessage[], options?: any, tools?: any[]) {
-    if (this.config.type === 'openai') {
+    if (this.config.type !== 'ollama') {
       // Implement OpenAI-specific request that returns the raw response
       return this.sendOpenAIRequest(model, messages, options, tools);
     } else {


### PR DESCRIPTION
## Summary
- add `litellm_base_url` and allow `litellm` api type
- update node components and settings UI for LiteLLM
- support litellm in execution engine and client
- test litellm execution

## Testing
- `npm run lint` *(fails: 767 errors)*
- `npm test`