### PR TITLE
Add LiteLLM provider support

### DIFF
--- a/src/ExecutionEngine.ts
+++ b/src/ExecutionEngine.ts
@@ -10,7 +10,7 @@ export interface ExecutionPlan {
   nodes: Node[];
   edges: Edge[];
   config: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };
@@ -32,7 +32,7 @@ export interface ExecutionContext {
   updateUi?: (type: string, nodeId: string, data: any) => void;
   updateNodeStatus?: (nodeId: string, status: 'running' | 'completed' | 'error') => void;
   apiConfig: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };
@@ -83,9 +83,9 @@ export function generateExecutionPlan(nodes: Node[], edges: Edge[]): ExecutionPl
     if (nodeConfig?.apiType == 'ollama') {
       config.baseUrl = nodeConfig.ollamaUrl || DEFAULT_LOCALHOST_URL;
       config.type = 'ollama';
-    } else if (nodeConfig?.apiType == 'openai') {
+    } else if (nodeConfig?.apiType == 'openai' || nodeConfig?.apiType == 'litellm') {
       config.baseUrl = nodeConfig.openaiUrl || DEFAULT_LOCALHOST_URL;
-      config.type = 'openai';
+      config.type = nodeConfig.apiType;
       config.apiKey = nodeConfig.apiKey;
     }
   } 

--- a/src/components/Assistant.tsx
+++ b/src/components/Assistant.tsx
@@ -112,7 +112,7 @@ const Assistant: React.FC<AssistantProps> = ({ onPageChange }) => {
     
     // Default config now sets mode to 'auto'
     return {
-      type: apiType as 'ollama' | 'openai',
+      type: apiType as 'ollama' | 'openai' | 'litellm',
       mode: 'auto',
       visionModel: '',
       toolModel: '',
@@ -539,7 +539,7 @@ const Assistant: React.FC<AssistantProps> = ({ onPageChange }) => {
         } else {
           // If no config exists for this API type, create default and show config modal
           const defaultConfig: ApiModelConfig = {
-            type: config.api_type as 'ollama' | 'openai',
+            type: config.api_type as 'ollama' | 'openai' | 'litellm',
             mode: 'manual',
             visionModel: '',
             toolModel: '',
@@ -600,7 +600,7 @@ const Assistant: React.FC<AssistantProps> = ({ onPageChange }) => {
     const apiType = client?.getConfig().type || 'ollama';
     const fullConfig: ApiModelConfig = {
       ...config,
-      type: apiType as 'ollama' | 'openai'
+      type: apiType as 'ollama' | 'openai' | 'litellm'
     };
 
     setModelSelectionConfig(fullConfig);
@@ -750,7 +750,7 @@ const Assistant: React.FC<AssistantProps> = ({ onPageChange }) => {
     const newConfig: ApiModelConfig = {
       ...modelSelectionConfig,
       mode,
-      type: apiType as 'ollama' | 'openai'
+      type: apiType as 'ollama' | 'openai' | 'litellm'
     };
 
     setModelSelectionConfig(newConfig);

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -40,7 +40,7 @@ const Onboarding = ({onComplete}: OnboardingProps) => {
         comfyui_url: 'http://localhost:8188',
         openai_api_key: '',
         openai_base_url: 'https://api.openai.com/v1',
-        api_type: 'ollama' as 'ollama' | 'openai'
+        api_type: 'ollama' as 'ollama' | 'openai' | 'litellm'
     });
     const [loading, setLoading] = useState(false);
     const [pingStatus, setPingStatus] = useState<'idle' | 'success' | 'error'>('idle');

--- a/src/components/UIBuilder.tsx
+++ b/src/components/UIBuilder.tsx
@@ -35,7 +35,7 @@ const UIBuilder: React.FC<UIBuilderProps> = ({ onPageChange }) => {
   const [chatMode, setChatMode] = useState<'chat' | 'design'>('design');
   const [selectedOllamaModel, setSelectedOllamaModel] = useState<OllamaModel | null>(null);
   const [selectedOpenAIModel, setSelectedOpenAIModel] = useState<OpenAIModel | null>(null);
-  const [apiType, setApiType] = useState<'ollama' | 'openai'>('ollama');
+  const [apiType, setApiType] = useState<'ollama' | 'openai' | 'litellm'>('ollama');
   const [isGenerating, setIsGenerating] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
   const [apiConfig, setApiConfig] = useState({
@@ -1009,7 +1009,7 @@ Reply ONLY with a JSON object like this:
     localStorage.setItem('openai_ui_builder_selected_model', JSON.stringify(model));
   };
 
-  const handleApiTypeChange = async (type: 'ollama' | 'openai') => {
+  const handleApiTypeChange = async (type: 'ollama' | 'openai' | 'litellm') => {
     console.log('UIBuilder: Changing API type to:', type);
     setApiType(type);
     

--- a/src/components/appcreator_components/nodes/BaseLlmNode.tsx
+++ b/src/components/appcreator_components/nodes/BaseLlmNode.tsx
@@ -26,7 +26,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
   const [nodeError, setNodeError] = useState<string | null>(null);
 
   // API selection settings
-  const [apiType, setApiType] = useState<'ollama' | 'openai'>(data.config.apiType || 'ollama');
+  const [apiType, setApiType] = useState<'ollama' | 'openai' | 'litellm'>(data.config.apiType || 'ollama');
   const [openaiApiKey, setOpenaiApiKey] = useState(data.config.apiKey || '');
   const [openaiUrl, setOpenaiUrl] = useState(data.config.openaiUrl || 'https://api.openai.com/v1');
   const [openaiModels, setOpenaiModels] = useState<string[]>([
@@ -43,7 +43,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
         
         // Set API type from global config if available
         if (config?.api_type && !data.config.apiType) {
-          setApiType(config.api_type as 'ollama' | 'openai');
+          setApiType(config.api_type as 'ollama' | 'openai' | 'litellm');
           data.config.apiType = config.api_type;
         }
         
@@ -133,7 +133,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
         }
         
         // If no model selected, set default
-        if (!model || (apiType === 'openai' && !openaiModels.includes(model))) {
+        if (!model || (apiType !== 'ollama' && !openaiModels.includes(model))) {
           const defaultModel = openaiModels[0] || 'gpt-3.5-turbo';
           setModel(defaultModel);
           data.config.model = defaultModel;
@@ -176,7 +176,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
 
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     e.stopPropagation();
-    setApiType(e.target.value as 'ollama' | 'openai');
+    setApiType(e.target.value as 'ollama' | 'openai' | 'litellm');
     data.config.apiType = e.target.value;
   };
   
@@ -247,6 +247,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
         >
           <option value="ollama">Ollama</option>
           <option value="openai">OpenAI</option>
+          <option value="litellm">LiteLLM</option>
         </select>
       </div>
       
@@ -353,8 +354,8 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
             ) : (
               apiType === 'ollama' ? (
                 displayedModels.map((m: any) => (
-                  <option 
-                    key={m.name} 
+                  <option
+                    key={m.name}
                     value={m.name}
                   >
                     {m.name} ({Math.round(m.size / 1024 / 1024 / 1024)}GB)
@@ -407,7 +408,7 @@ const BaseLlmNode = ({ data, isConnectable }: any) => {
       {/* API provider info */}
       <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mb-2">
         <Database size={12} />
-        <span>Using {apiType === 'ollama' ? 'Ollama' : 'OpenAI'} API</span>
+        <span>Using {apiType === 'ollama' ? 'Ollama' : apiType === 'litellm' ? 'LiteLLM' : 'OpenAI'} API</span>
       </div>
       
       <Handle

--- a/src/components/appcreator_components/nodes/ImageTextLlmNode.tsx
+++ b/src/components/appcreator_components/nodes/ImageTextLlmNode.tsx
@@ -21,7 +21,7 @@ const ImageTextLlmNode: React.FC<any> = ({ data, isConnectable }) => {
   const [customUrl, setCustomUrl] = useState(data.config?.ollamaUrl || '');
 
   // API selection and models
-  const [apiType, setApiType] = useState<'ollama' | 'openai'>(data.config?.apiType || 'ollama');
+  const [apiType, setApiType] = useState<'ollama' | 'openai' | 'litellm'>(data.config?.apiType || 'ollama');
   const [openaiApiKey, setOpenaiApiKey] = useState(data.config?.apiKey || '');
   const [openaiUrl, setOpenaiUrl] = useState(data.config?.openaiUrl || 'https://api.openai.com/v1');
 
@@ -50,7 +50,7 @@ const ImageTextLlmNode: React.FC<any> = ({ data, isConnectable }) => {
         
         // Set API type from global config if available
         if (config?.api_type && !data.config.apiType) {
-          setApiType(config.api_type as 'ollama' | 'openai');
+          setApiType(config.api_type as 'ollama' | 'openai' | 'litellm');
           data.config.apiType = config.api_type;
         }
         
@@ -201,7 +201,7 @@ const ImageTextLlmNode: React.FC<any> = ({ data, isConnectable }) => {
 
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     e.stopPropagation();
-    setApiType(e.target.value as 'ollama' | 'openai');
+    setApiType(e.target.value as 'ollama' | 'openai' | 'litellm');
     data.config.apiType = e.target.value;
   };
   
@@ -280,6 +280,7 @@ const ImageTextLlmNode: React.FC<any> = ({ data, isConnectable }) => {
         >
           <option value="ollama">Ollama</option>
           <option value="openai">OpenAI</option>
+          <option value="litellm">LiteLLM</option>
         </select>
       </div>
       
@@ -467,7 +468,7 @@ const ImageTextLlmNode: React.FC<any> = ({ data, isConnectable }) => {
       {/* API provider info */}
       <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mb-3">
         <Database size={12} />
-        <span>Using {apiType === 'ollama' ? 'Ollama' : 'OpenAI'} API</span>
+        <span>Using {apiType === 'ollama' ? 'Ollama' : apiType === 'litellm' ? 'LiteLLM' : 'OpenAI'} API</span>
       </div>
       
       <div className="mb-3 p-2 bg-blue-50 dark:bg-blue-900/30 rounded">

--- a/src/components/appcreator_components/nodes/StructuredLlmNode.tsx
+++ b/src/components/appcreator_components/nodes/StructuredLlmNode.tsx
@@ -28,7 +28,7 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
   const [nodeError, setNodeError] = useState<string | null>(null);
 
   // Add OpenAI specific settings
-  const [apiType, setApiType] = useState<'ollama' | 'openai'>(data.config.apiType || 'ollama');
+  const [apiType, setApiType] = useState<'ollama' | 'openai' | 'litellm'>(data.config.apiType || 'ollama');
   const [openaiApiKey, setOpenaiApiKey] = useState(data.config.apiKey || '');
   const [openaiUrl, setOpenaiUrl] = useState(data.config.openaiUrl || 'https://api.openai.com/v1');
   const [openaiModels, setOpenaiModels] = useState<string[]>([
@@ -53,7 +53,7 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
         const config = await db.getAPIConfig();
         // Set API type from global config if available
         if (config?.api_type && !data.config.apiType) {
-          setApiType(config.api_type as 'ollama' | 'openai');
+          setApiType(config.api_type as 'ollama' | 'openai' | 'litellm');
           data.config.apiType = config.api_type;
         }
         
@@ -124,7 +124,7 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
         }
         
         // If no model selected, set default
-        if (!model || (apiType === 'openai' && !openaiModels.includes(model))) {
+        if (!model || (apiType !== 'ollama' && !openaiModels.includes(model))) {
           const defaultModel = openaiModels[0] || 'gpt-4-turbo';
           setModel(defaultModel);
           data.config.model = defaultModel;
@@ -227,12 +227,12 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
 
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     e.stopPropagation();
-    const newApiType = e.target.value as 'ollama' | 'openai';
+    const newApiType = e.target.value as 'ollama' | 'openai' | 'litellm';
     setApiType(newApiType);
     data.config.apiType = newApiType;
-    
+
     // Reset custom model input when switching API types
-    if (newApiType === 'openai') {
+    if (newApiType !== 'ollama') {
       setCustomModelInput(model);
     }
   };
@@ -309,6 +309,7 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
         >
           <option value="ollama">Ollama</option>
           <option value="openai">OpenAI</option>
+          <option value="litellm">LiteLLM</option>
         </select>
       </div>
       
@@ -536,7 +537,7 @@ const StructuredLLMNode: React.FC<{ data: any; isConnectable: boolean }> = ({ da
       {/* API provider info */}
       <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mb-2">
         <Database size={12} />
-        <span>Using {apiType === 'ollama' ? 'Ollama' : 'OpenAI'} API</span>
+        <span>Using {apiType === 'ollama' ? 'Ollama' : apiType === 'litellm' ? 'LiteLLM' : 'OpenAI'} API</span>
       </div>
       
       <Handle

--- a/src/components/assistant_components/OnboardingModal.tsx
+++ b/src/components/assistant_components/OnboardingModal.tsx
@@ -17,7 +17,7 @@ interface ModelSelectionConfig extends ModelConfig {
 }
 
 interface APIConfig {
-  api_type: 'ollama' | 'openai';
+  api_type: 'ollama' | 'openai' | 'litellm';
   ollama_base_url: string;
   openai_base_url: string;
   openai_api_key: string;
@@ -117,7 +117,7 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
           setApiConfig({
             ...defaultApiConfig,  // Start with defaults
             ...savedApiConfig,    // Override with saved values
-            api_type: (savedApiConfig.api_type === 'openai' ? 'openai' : 'ollama') as 'ollama' | 'openai',
+            api_type: (savedApiConfig.api_type === 'openai' ? 'openai' : savedApiConfig.api_type === 'litellm' ? 'litellm' : 'ollama') as 'ollama' | 'openai' | 'litellm',
           });
 
           // Automatically test connection with saved config

--- a/src/components/uibuilder_components/ChatPanel.tsx
+++ b/src/components/uibuilder_components/ChatPanel.tsx
@@ -12,7 +12,7 @@ interface ChatPanelProps {
   onModeChange: (mode: 'chat' | 'design') => void;
   selectedModel: OllamaModel | OpenAIModel | null;
   onModelSelect: (model: OllamaModel | OpenAIModel) => void;
-  apiType?: 'ollama' | 'openai';
+  apiType?: 'ollama' | 'openai' | 'litellm';
   onRestoreCheckpoint?: (code: { html: string; css: string; js: string; find?: string; replace?: string }) => void;
   isGenerating?: boolean;
   isProcessing?: boolean;
@@ -40,6 +40,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
   const [apiConfig, setApiConfig] = useState<{
     openai_api_key?: string;
     openai_base_url?: string;
+    litellm_base_url?: string;
   }>({});
   const [expandedMessages, setExpandedMessages] = useState<{ [key: number]: boolean }>({});
   const [expandedThink, setExpandedThink] = useState<{ [key: string]: boolean }>({});
@@ -52,7 +53,8 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
       if (config) {
         setApiConfig({
           openai_api_key: config.openai_api_key || '',
-          openai_base_url: config.openai_base_url || 'https://api.openai.com/v1'
+          openai_base_url: config.openai_base_url || 'https://api.openai.com/v1',
+          litellm_base_url: config.litellm_base_url || 'http://localhost:4000'
         });
       }
     };
@@ -189,7 +191,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                 onModelSelect={handleModelSelect as (model: OpenAIModel) => void}
                 selectedModelId={(selectedModel as OpenAIModel)?.id}
                 apiKey={apiConfig.openai_api_key}
-                baseUrl={apiConfig.openai_base_url}
+                baseUrl={apiType === 'litellm' ? apiConfig.litellm_base_url : apiConfig.openai_base_url}
                 compact={true}
               />
             )}

--- a/src/components/uibuilder_components/ui_builder_libraries/ApiTypeSelector.tsx
+++ b/src/components/uibuilder_components/ui_builder_libraries/ApiTypeSelector.tsx
@@ -3,7 +3,7 @@ import { Settings, Server, ExternalLink } from 'lucide-react';
 import { db } from '../../../db';
 
 interface ApiTypeSelectorProps {
-  onApiTypeChange: (apiType: 'ollama' | 'openai') => void;
+  onApiTypeChange: (apiType: 'ollama' | 'openai' | 'litellm') => void;
   currentApiType: string;
   onPageChange: (page: string) => void;
 }
@@ -19,11 +19,13 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
     ollama_base_url?: string;
     openai_base_url?: string;
     openai_api_key?: string;
+    litellm_base_url?: string;
   }>({
     api_type: currentApiType,
     ollama_base_url: '',
     openai_base_url: '',
-    openai_api_key: ''
+    openai_api_key: '',
+    litellm_base_url: ''
   });
 
   useEffect(() => {
@@ -36,7 +38,8 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
             api_type: config.api_type || 'ollama',
             ollama_base_url: config.ollama_base_url || '',
             openai_base_url: config.openai_base_url || '',
-            openai_api_key: config.openai_api_key || ''
+            openai_api_key: config.openai_api_key || '',
+            litellm_base_url: config.litellm_base_url || ''
           });
         }
       } catch (error) {
@@ -51,7 +54,7 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
     setIsOpen(!isOpen);
   };
 
-  const handleSelectApiType = async (type: 'ollama' | 'openai') => {
+  const handleSelectApiType = async (type: 'ollama' | 'openai' | 'litellm') => {
     try {
       // Update local state
       setApiConfig(prev => ({ ...prev, api_type: type }));
@@ -88,7 +91,7 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
         title="API Settings"
       >
         <Settings className="w-3.5 h-3.5" />
-        <span>API: {currentApiType === 'openai' ? 'OpenAI' : 'Ollama'}</span>
+        <span>API: {currentApiType === 'openai' ? 'OpenAI' : currentApiType === 'litellm' ? 'LiteLLM' : 'Ollama'}</span>
       </button>
 
       {isOpen && (
@@ -119,6 +122,18 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
               >
                 <ExternalLink className="w-3.5 h-3.5 mr-2" />
                 <span>OpenAI API</span>
+              </button>
+
+              <button
+                onClick={() => handleSelectApiType('litellm')}
+                className={`flex items-center w-full px-3 py-2 text-xs rounded-md transition-colors ${
+                  currentApiType === 'litellm'
+                    ? 'bg-sakura-100 dark:bg-sakura-900/30 text-sakura-800 dark:text-sakura-300'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'
+                }`}
+              >
+                <ExternalLink className="w-3.5 h-3.5 mr-2" />
+                <span>LiteLLM</span>
               </button>
             </div>
             

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -65,8 +65,8 @@ export interface APIConfig {
   comfyui_base_url: string;
   openai_api_key ?: string;
   openai_base_url ?: string;
-  openrouter_api_key ?: string;
-  api_type ?: string;
+  litellm_base_url?: string;
+  api_type ?: 'ollama' | 'openai' | 'litellm';
   n8n_base_url?: string;  // URL of the n8n instance
   n8n_api_key?: string;   // API Key for n8n
 }

--- a/src/nodeExecutors/BaseLlmExecutor.tsx
+++ b/src/nodeExecutors/BaseLlmExecutor.tsx
@@ -16,7 +16,7 @@ const executeLlmPrompt = async (context: NodeExecutionContext) => {
     const ollamaUrl = config.ollamaUrl || 'http://localhost:11434';
     
     // Determine which API to use (from node config or from global context)
-    const useOpenAI = apiConfig?.type === 'openai' || config.apiType === 'openai';
+    const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
     
     console.log(`Executing LLM with model: ${model}, system prompt: ${systemPrompt}, API type: ${useOpenAI ? 'OpenAI' : 'Ollama'}`);
     

--- a/src/nodeExecutors/ImageTextLlmExecutor.tsx
+++ b/src/nodeExecutors/ImageTextLlmExecutor.tsx
@@ -69,7 +69,7 @@ const executeImageTextLlm = async (context: NodeExecutionContext): Promise<strin
     const ollamaUrl = config.ollamaUrl || node.data?.ollamaUrl;
     
     // Determine which API to use (from node config or from global context)
-    const useOpenAI = apiConfig?.type === 'openai' || config.apiType === 'openai';
+    const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
     
     if (!ollamaUrl && !ollamaClient && !useOpenAI) {
       return "Error: No API URL configured. Please set the URL in the node settings.";

--- a/src/nodeExecutors/NodeExecutorRegistry.tsx
+++ b/src/nodeExecutors/NodeExecutorRegistry.tsx
@@ -7,7 +7,7 @@ export interface NodeExecutionContext {
   inputs: { [key: string]: any };
   ollamaClient: OllamaClient;
   apiConfig: {
-    type: 'ollama' | 'openai';
+    type: 'ollama' | 'openai' | 'litellm';
     baseUrl: string;
     apiKey?: string;
   };

--- a/src/nodeExecutors/structuredLlmExecutor.tsx
+++ b/src/nodeExecutors/structuredLlmExecutor.tsx
@@ -105,7 +105,7 @@ const executeStructuredLLM = async (context: NodeExecutionContext): Promise<stri
     const ollamaUrl = config.ollamaUrl || 'http://localhost:11434';
     
     // Determine which API to use (from node config or from global context)
-    const useOpenAI = apiConfig?.type === 'openai' || config.apiType === 'openai';
+    const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
     
     console.log(`Executing Structured LLM with:
     - Model: ${model}

--- a/src/utils/OllamaClient.ts
+++ b/src/utils/OllamaClient.ts
@@ -17,7 +17,7 @@ export interface RequestOptions {
 export interface OpenAIConfig {
   apiKey: string;
   baseUrl: string;
-  type: 'ollama' | 'openai';
+  type: 'ollama' | 'openai' | 'litellm';
 }
 
 interface APIResponse {
@@ -108,7 +108,7 @@ export class OllamaClient {
       'Content-Type': 'application/json'
     };
 
-    if (this.config.type === 'openai' && this.config.apiKey) {
+    if (this.config.type !== 'ollama' && this.config.apiKey) {
       headers['Authorization'] = `Bearer ${this.config.apiKey}`;
     }
 
@@ -144,7 +144,7 @@ export class OllamaClient {
         'Content-Type': 'application/json'
       };
       
-      if (this.config.type === 'openai' && this.config.apiKey) {
+      if (this.config.type !== 'ollama' && this.config.apiKey) {
         headers['Authorization'] = `Bearer ${this.config.apiKey}`;
       }
       
@@ -880,7 +880,7 @@ Your response MUST be a valid JSON object, properly formatted and parsable.`;
   }
 
   private formatTool(tool: BaseTool): OpenAITool | OllamaTool {
-    if (this.config.type === 'openai') {
+    if (this.config.type !== 'ollama') {
       return {
         type: 'function',
         ...tool
@@ -911,7 +911,7 @@ Your response MUST be a valid JSON object, properly formatted and parsable.`;
 
   // Add a new method specifically for tool calls that preserves OpenAI response format
   async sendChatWithToolsPreserveFormat(model: string, messages: ChatMessage[], options?: any, tools?: any[]) {
-    if (this.config.type === 'openai') {
+    if (this.config.type !== 'ollama') {
       // Implement OpenAI-specific request that returns the raw response
       return this.sendOpenAIRequest(model, messages, options, tools);
     } else {


### PR DESCRIPTION
## Summary
- support `litellm` as a new API type in APIConfig
- include `litellm` choice in assistant settings and node components
- update execution engine and node executors to route requests to LiteLLM
- display LiteLLM option in UI builder components
- remove unused `openrouter_api_key`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: no output)*

## Summary by Sourcery

Add LiteLLM as a first‐class API provider and remove unused OpenRouter key

New Features:
- Support "litellm" as a new API type in global and node configurations, database schema, and client logic
- Add LiteLLM option in assistant settings, UI builder components, and model selection dropdowns with corresponding base URL handling
- Route LiteLLM requests through existing OpenAI-compatible flow in the execution engine and node executors

Chores:
- Remove unused openrouter_api_key configuration