### PR TITLE
Remove unused openrouter_api_key

### DIFF
--- a/src/components/assistant_components/AssistantSettings.tsx
+++ b/src/components/assistant_components/AssistantSettings.tsx
@@ -12,7 +12,7 @@ interface ModelConfig {
   name: string;
   supportsImages: boolean;
   digest?: string;
-  apiType?: 'ollama' | 'openai' | 'openrouter';
+  apiType?: 'ollama' | 'openai';
 }
 
 interface AssistantSettingsProps {
@@ -149,7 +149,6 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
             api_type: config.api_type || 'ollama',
             openai_api_key: config.openai_api_key,
             openai_base_url: config.openai_base_url || 'https://api.openai.com/v1',
-            openrouter_api_key: config.openrouter_api_key,
             n8n_base_url: config.n8n_base_url,
             n8n_api_key: config.n8n_api_key
           };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -65,7 +65,6 @@ export interface APIConfig {
   comfyui_base_url: string;
   openai_api_key ?: string;
   openai_base_url ?: string;
-  openrouter_api_key ?: string;
   api_type ?: string;
   n8n_base_url?: string;  // URL of the n8n instance
   n8n_api_key?: string;   // API Key for n8n


### PR DESCRIPTION
## Summary
- drop `openrouter_api_key` from APIConfig
- remove the unused field from AssistantSettings

## Testing
- `npm run lint` *(fails: lots of existing lint errors)*
- `npm test` *(fails: couldn't load test setup)*