### PR TITLE
Add litellmUrl support in ExecutionEngine

### DIFF
--- a/codebase_readme.md
+++ b/codebase_readme.md
@@ -273,3 +273,5 @@ Key configuration options:
 - `MAX_CONTEXT_MESSAGES`: 20 messages
 - `MAX_IMAGE_SIZE`: 10MB
 - Model image support configuration in localStorage
+- `litellmUrl`: Base URL for a LiteLLM server when `apiType` is `litellm`
+

--- a/src/components/AppCreator.tsx
+++ b/src/components/AppCreator.tsx
@@ -390,7 +390,7 @@ const AppCreator: React.FC<AppCreatorProps> = ({ onPageChange, appId }) => {
     setIsExecuting(true);
     setNodeStatuses({});  // Reset node statuses
     try {
-      const plan = generateExecutionPlan(nodes, edges);
+      const plan = await generateExecutionPlan(nodes, edges);
       const updateNodeOutput = (nodeId: string, output: any) => {
         setNodes((nds) =>
           nds.map((node) => {
@@ -485,8 +485,8 @@ const AppCreator: React.FC<AppCreatorProps> = ({ onPageChange, appId }) => {
     [nodes]
   );
 
-  const handleDebug = () => {
-    const plan = generateExecutionPlan(nodes, edges);
+  const handleDebug = async () => {
+    const plan = await generateExecutionPlan(nodes, edges);
     setExecutionJson(plan);
     setDebugOpen(true);
   };

--- a/src/components/AppRunner.tsx
+++ b/src/components/AppRunner.tsx
@@ -415,7 +415,7 @@ Current request: ${currentInput}`;
       await appStore.tempUpdateAppNodes(appId, appDataClone.nodes);
 
       // Generate execution plan & run
-      const plan = generateExecutionPlan(appDataClone.nodes, appDataClone.edges);
+      const plan = await generateExecutionPlan(appDataClone.nodes, appDataClone.edges);
 
       // Callback to capture node outputs
       const updateNodeOutput = (nodeId: string, output: any) => {

--- a/src/components/widget-components/AppWidget.tsx
+++ b/src/components/widget-components/AppWidget.tsx
@@ -102,7 +102,7 @@ const AppWidget: React.FC<AppWidgetProps> = ({
       await appStore.tempUpdateAppNodes(appId, appDataClone.nodes);
 
       // Generate and execute flow
-      const plan = generateExecutionPlan(appDataClone.nodes, appDataClone.edges);
+      const plan = await generateExecutionPlan(appDataClone.nodes, appDataClone.edges);
 
       // Callback to capture node outputs
       const updateNodeOutput = (nodeId: string, output: any) => {


### PR DESCRIPTION
## Summary
- allow ExecutionEngine to read `litellmUrl` from node or global settings
- expose `litellmUrl` in `ExecutionPlan` and runtime API config
- update callers for the new async `generateExecutionPlan`
- document the new configuration option

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails to load /src/test/setup.ts)*

## Summary by Sourcery

Enable LiteLLM integration by introducing a `litellmUrl` option, making execution plan generation asynchronous to fetch global API settings, updating callers accordingly, and documenting the new configuration.

New Features:
- Support LiteLLM backend via `litellmUrl` in ExecutionPlan and runtime API configuration

Enhancements:
- Convert generateExecutionPlan to async and fetch global API configuration from the database
- Extend APIConfig resolution to pull base URLs and API keys for Ollama, OpenAI, and LiteLLM from node or global settings
- Update components (AppCreator, AppRunner, AppWidget) to await the asynchronous generateExecutionPlan function

Documentation:
- Add documentation for the new `litellmUrl` configuration option in the codebase README