### PR TITLE
Add LiteLLM support

### DIFF
--- a/src/ExecutionEngine.ts
+++ b/src/ExecutionEngine.ts
@@ -83,12 +83,16 @@ export function generateExecutionPlan(nodes: Node[], edges: Edge[]): ExecutionPl
     if (nodeConfig?.apiType == 'ollama') {
       config.baseUrl = nodeConfig.ollamaUrl || DEFAULT_LOCALHOST_URL;
       config.type = 'ollama';
-    } else if (nodeConfig?.apiType == 'openai' || nodeConfig?.apiType == 'litellm') {
+    } else if (nodeConfig?.apiType == 'openai') {
       config.baseUrl = nodeConfig.openaiUrl || DEFAULT_LOCALHOST_URL;
-      config.type = nodeConfig.apiType;
+      config.type = 'openai';
+      config.apiKey = nodeConfig.apiKey;
+    } else if (nodeConfig?.apiType == 'litellm') {
+      config.baseUrl = nodeConfig.litellmUrl || DEFAULT_LOCALHOST_URL;
+      config.type = 'litellm';
       config.apiKey = nodeConfig.apiKey;
     }
-  } 
+  }
 
   return { nodes, edges, config };
 }

--- a/src/nodeExecutors/BaseLlmExecutor.tsx
+++ b/src/nodeExecutors/BaseLlmExecutor.tsx
@@ -14,6 +14,7 @@ const executeLlmPrompt = async (context: NodeExecutionContext) => {
     const model = config.model || 'llama2';
     const systemPrompt = config.prompt || '';
     const ollamaUrl = config.ollamaUrl || 'http://localhost:11434';
+    const litellmUrl = config.litellmUrl || 'http://localhost:4000';
     
     // Determine which API to use (from node config or from global context)
     const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
@@ -33,9 +34,13 @@ const executeLlmPrompt = async (context: NodeExecutionContext) => {
     // If no client provided or we need to override the API type
     if (!client || (useOpenAI && client.getConfig().type !== 'openai')) {
       if (useOpenAI) {
-        // Use OpenAI configuration
+        // Use OpenAI or LiteLLM configuration
+        const baseUrl =
+          apiConfig?.type === 'litellm' || config.apiType === 'litellm'
+            ? apiConfig?.baseUrl || litellmUrl
+            : apiConfig?.baseUrl || config.openaiUrl || 'https://api.openai.com/v1';
         client = new OllamaClient(
-          apiConfig?.baseUrl || config.openaiUrl || 'https://api.openai.com/v1', 
+          baseUrl,
           {
             apiKey: apiConfig?.apiKey || config.apiKey || '',
             type: 'openai'

--- a/src/nodeExecutors/ImageTextLlmExecutor.tsx
+++ b/src/nodeExecutors/ImageTextLlmExecutor.tsx
@@ -67,6 +67,7 @@ const executeImageTextLlm = async (context: NodeExecutionContext): Promise<strin
     
     const systemPrompt = config.systemPrompt || node.data?.systemPrompt || '';
     const ollamaUrl = config.ollamaUrl || node.data?.ollamaUrl;
+    const litellmUrl = config.litellmUrl || 'http://localhost:4000';
     
     // Determine which API to use (from node config or from global context)
     const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
@@ -86,9 +87,13 @@ const executeImageTextLlm = async (context: NodeExecutionContext): Promise<strin
     // If no client provided or we need to override the API type
     if (!client || (useOpenAI && client.getConfig().type !== 'openai')) {
       if (useOpenAI) {
-        // Use OpenAI configuration
+        // Use OpenAI or LiteLLM configuration
+        const baseUrl =
+          apiConfig?.type === 'litellm' || config.apiType === 'litellm'
+            ? apiConfig?.baseUrl || litellmUrl
+            : apiConfig?.baseUrl || config.openaiUrl || 'https://api.openai.com/v1';
         client = new OllamaClient(
-          apiConfig?.baseUrl || config.openaiUrl || 'https://api.openai.com/v1', 
+          baseUrl,
           {
             apiKey: apiConfig?.apiKey || config.apiKey || '',
             type: 'openai'

--- a/src/nodeExecutors/structuredLlmExecutor.tsx
+++ b/src/nodeExecutors/structuredLlmExecutor.tsx
@@ -103,6 +103,7 @@ const executeStructuredLLM = async (context: NodeExecutionContext): Promise<stri
     const model = config.model || 'llama2';
     const systemPrompt = config.prompt || '';
     const ollamaUrl = config.ollamaUrl || 'http://localhost:11434';
+    const litellmUrl = config.litellmUrl || 'http://localhost:4000';
     
     // Determine which API to use (from node config or from global context)
     const useOpenAI = apiConfig?.type === 'openai' || apiConfig?.type === 'litellm' || config.apiType === 'openai' || config.apiType === 'litellm';
@@ -139,7 +140,10 @@ const executeStructuredLLM = async (context: NodeExecutionContext): Promise<stri
     if (useOpenAI) {
       // Use OpenAI SDK with dangerouslyAllowBrowser flag
       const openaiApiKey = apiConfig?.apiKey || config.apiKey || '';
-      const openaiBaseUrl = apiConfig?.baseUrl || config.openaiUrl || undefined; // Use default if not provided
+      const openaiBaseUrl =
+        apiConfig?.type === 'litellm' || config.apiType === 'litellm'
+          ? apiConfig?.baseUrl || litellmUrl
+          : apiConfig?.baseUrl || config.openaiUrl || undefined; // Use default if not provided
       
       const openai = new OpenAI({
         apiKey: openaiApiKey,


### PR DESCRIPTION
## Summary
- add `litellmUrl` to LLM node configs
- handle LiteLLM base URL in executor logic
- update execution planning for LiteLLM nodes

## Testing
- `npm run lint` *(fails: unexpected any, unused vars)*
- `npm test` *(fails: Failed to load url /workspace/KBVerse/src/test/setup.ts)*

## Summary by Sourcery

Add LiteLLM as a third LLM provider option across the app creator by extending node components, execution planning, and executors to recognize, configure, and route to LiteLLM endpoints.

New Features:
- Expose LiteLLM API URL input and selection option in Base, Structured, and ImageText LLM node settings
- Introduce 'litellm' API type for nodes to fetch and display LiteLLM models
- Enhance ExecutionEngine to generate execution plans for LiteLLM nodes
- Update node executors to route prompts and image-text workloads to LiteLLM endpoints when selected

Enhancements:
- Unify OpenAI and LiteLLM model-fetching logic in client initialization
- Include LiteLLM base URL in config loading and useEffect dependency arrays