### PR TITLE
Support litellm image generation

### DIFF
--- a/src/utils/AssistantOllamaClient.test.ts
+++ b/src/utils/AssistantOllamaClient.test.ts
@@ -1,0 +1,99 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AssistantOllamaClient } from './AssistantOllamaClient';
+
+function mockFetch(json: any) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(json)
+  } as Response);
+}
+
+function createStream(lines: string[]) {
+  return {
+    getReader() {
+      let index = 0;
+      return {
+        read() {
+          if (index < lines.length) {
+            const value = new TextEncoder().encode(lines[index]);
+            index++;
+            return Promise.resolve({ value, done: false });
+          }
+          return Promise.resolve({ value: undefined, done: true });
+        }
+      };
+    }
+  } as any;
+}
+
+describe('AssistantOllamaClient image generation', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses OpenAI flow when type is openai', async () => {
+    (fetch as any).mockImplementation(() =>
+      mockFetch({ choices: [{ message: { content: 'hi' } }], usage: { total_tokens: 5 } })
+    );
+
+    const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'openai' });
+    const result = await client.generateWithImages('model', 'prompt', ['img']);
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect(result).toEqual({ response: 'hi', eval_count: 5 });
+  });
+
+  it('uses OpenAI flow when type is litellm', async () => {
+    (fetch as any).mockImplementation(() =>
+      mockFetch({ choices: [{ message: { content: 'hi' } }], usage: { total_tokens: 5 } })
+    );
+
+    const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'litellm' });
+    const result = await client.generateWithImages('model', 'prompt', ['img']);
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect(result).toEqual({ response: 'hi', eval_count: 5 });
+  });
+
+  it('streams responses when type is openai', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      body: createStream(['data: {"choices":[{"delta":{"content":"hello"}}]}\n'])
+    });
+
+    const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'openai' });
+    const gen = client.streamGenerateWithImages('model', 'prompt', ['img']);
+    const chunks: any[] = [];
+    for await (const chunk of gen) {
+      chunks.push(chunk);
+    }
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect(chunks).toEqual([{ response: 'hello', eval_count: 0 }]);
+  });
+
+  it('streams responses when type is litellm', async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      body: createStream(['data: {"choices":[{"delta":{"content":"hello"}}]}\n'])
+    });
+
+    const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'litellm' });
+    const gen = client.streamGenerateWithImages('model', 'prompt', ['img']);
+    const chunks: any[] = [];
+    for await (const chunk of gen) {
+      chunks.push(chunk);
+    }
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect(chunks).toEqual([{ response: 'hello', eval_count: 0 }]);
+  });
+});

--- a/src/utils/AssistantOllamaClient.ts
+++ b/src/utils/AssistantOllamaClient.ts
@@ -34,7 +34,7 @@ export class AssistantOllamaClient extends OllamaClient {
     // Use vision model if configured, otherwise fall back to default
     const model = this.modelConfig.visionModel || defaultModel;
 
-    if (this.getConfig().type === 'openai') {
+    if (this.getConfig().type === 'openai' || this.getConfig().type === 'litellm') {
       // Format messages for OpenAI's vision API
       const messages = [{
         role: 'user',
@@ -85,7 +85,7 @@ export class AssistantOllamaClient extends OllamaClient {
     // Use vision model if configured, otherwise fall back to default
     const model = this.modelConfig.visionModel || defaultModel;
     
-    if (this.getConfig().type === 'openai') {
+    if (this.getConfig().type === 'openai' || this.getConfig().type === 'litellm') {
       // Format messages for OpenAI's vision API
       const messages = [{
         role: 'user',

--- a/src/utils/OllamaClient.ts
+++ b/src/utils/OllamaClient.ts
@@ -506,62 +506,65 @@ export class OllamaClient {
           ...options
         });
       }
-  
-      // Structure messages for OpenAI vision API
-      const formattedContent = [
-        {
-          type: "text",
-          text: prompt
-        },
-        ...images.map(img => ({
-          type: "image_url",
-          image_url: {
-            url: img.startsWith('data:') ? img : `data:image/jpeg;base64,${img}`
+
+      if (this.config.type === 'openai' || this.config.type === 'litellm') {
+        // Structure messages for OpenAI vision API
+        const formattedContent = [
+          {
+            type: "text",
+            text: prompt
+          },
+          ...images.map(img => ({
+            type: "image_url",
+            image_url: {
+              url: img.startsWith('data:') ? img : `data:image/jpeg;base64,${img}`
+            }
+          }))
+        ];
+
+        const messages = [
+          {
+            role: "user",
+            content: formattedContent
           }
-        }))
-      ];
-  
-      const messages = [
-        {
-          role: "user",
-          content: formattedContent
-        }
-      ];
-  
-      console.log('OpenAI Vision Request:', {
-        model,
-        messages,
-        max_tokens: options.max_tokens || 1000
-      });
-  
-      try {
-        const response = await this.request("/chat/completions", "POST", {
+        ];
+
+        console.log('OpenAI Vision Request:', {
           model,
           messages,
-          max_tokens: options.max_tokens || 1000,
-          ...options
+          max_tokens: options.max_tokens || 1000
         });
-  
-        console.log('OpenAI Vision Response:', response);
-  
-        if (!response.choices?.[0]?.message) {
-          throw new Error('Invalid response format from image generation');
-        }
-  
-        return {
-          response: response.choices[0].message.content,
-          eval_count: response.usage?.total_tokens || 0
-        };
-      } catch (error) {
-        console.error('Vision API Error:', error);
-        // Return error in a format that can be displayed in chat
-        throw new Error(JSON.stringify({
-          error: {
-            message: error instanceof Error ? error.message : 'Unknown error occurred',
-            type: 'vision_api_error'
+
+        try {
+          const response = await this.request("/chat/completions", "POST", {
+            model,
+            messages,
+            max_tokens: options.max_tokens || 1000,
+            ...options
+          });
+
+          console.log('OpenAI Vision Response:', response);
+
+          if (!response.choices?.[0]?.message) {
+            throw new Error('Invalid response format from image generation');
           }
-        }, null, 2));
+
+          return {
+            response: response.choices[0].message.content,
+            eval_count: response.usage?.total_tokens || 0
+          };
+        } catch (error) {
+          console.error('Vision API Error:', error);
+          // Return error in a format that can be displayed in chat
+          throw new Error(JSON.stringify({
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error occurred',
+              type: 'vision_api_error'
+            }
+          }, null, 2));
+        }
       }
+  
     } catch (error) {
       console.error('Vision API Error:', error);
       // Return error in a format that can be displayed in chat


### PR DESCRIPTION
## Summary
- support `litellm` in vision APIs
- test that OpenAI and Litellm flows work for image generation

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: Failed to load setup file)*

## Summary by Sourcery

Enable litellm as a vision API option alongside OpenAI for image generation and add tests to ensure both providers function correctly

New Features:
- Add support for the litellm provider in vision-based image generation flows

Enhancements:
- Unify OpenAI and litellm image generation logic under the same request path in OllamaClient and AssistantOllamaClient

Tests:
- Introduce Vitest tests to verify image generation and streaming responses for both openai and litellm types