### PR TITLE
Fix model endpoint logic

### DIFF
--- a/src/utils/OllamaClient.test.ts
+++ b/src/utils/OllamaClient.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { OllamaClient } from './OllamaClient';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('OllamaClient.checkConnection', () => {
+  it('uses /api/tags for ollama type', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = mockFetch as any;
+    const client = new OllamaClient('http://localhost:11434', { type: 'ollama' });
+    const result = await client.checkConnection();
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:11434/api/tags', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  });
+
+  it('uses /models for non-ollama type', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = mockFetch as any;
+    const client = new OllamaClient('https://api.example.com/v1', {
+      type: 'openai',
+      apiKey: 'secret'
+    });
+    const result = await client.checkConnection();
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/v1/models', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer secret'
+      }
+    });
+  });
+});

--- a/src/utils/OllamaClient.ts
+++ b/src/utils/OllamaClient.ts
@@ -839,11 +839,15 @@ Your response MUST be a valid JSON object, properly formatted and parsable.`;
 
   async checkConnection(): Promise<boolean> {
     try {
-      // Use the list models endpoint to check connection
-      const response = await fetch(`${this.config.baseUrl}/api/tags`, {
+      // Choose endpoint based on API type
+      const endpoint = this.config.type === 'ollama' ? '/api/tags' : '/models';
+      const response = await fetch(`${this.config.baseUrl}${endpoint}`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          ...(this.config.type !== 'ollama' && this.config.apiKey
+            ? { Authorization: `Bearer ${this.config.apiKey}` }
+            : {}),
         },
       });
       return response.ok;


### PR DESCRIPTION
## Summary
- update checkConnection to pick correct endpoint
- add tests for both endpoint styles

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm test` *(fails: Failed to load url src/test/setup.ts)*

## Summary by Sourcery

Fix endpoint logic in OllamaClient.checkConnection to choose '/api/tags' for Ollama and '/models' for other API types with conditional authorization header, and add unit tests for both scenarios.

Bug Fixes:
- Correct checkConnection to select the appropriate API endpoint based on client type and include the authorization header only for non-Ollama types.

Tests:
- Add unit tests for checkConnection covering both Ollama ('/api/tags') and non-Ollama ('/models') endpoint styles.