### PR TITLE
Add LiteLLM support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ npm run build              # Web
 npm run electron:build     # Desktop
 ```
 
+## ⚡ LiteLLM Support
+
+Clara can talk to a [LiteLLM](https://github.com/BerriAI/litellm) server in place
+of OpenAI. Run a LiteLLM instance and open **Settings → LLM Provider** to select
+"LiteLLM" as the API type. The **Base URL** field points to your LiteLLM server
+and defaults to `http://localhost:4000`. Update this field in the UI if your
+LiteLLM endpoint runs elsewhere.
+
 ---
 
 ## 📈 GitHub Star Growth


### PR DESCRIPTION
## Summary
- document LiteLLM support in README

## Testing
- `git status --short`

## Summary by Sourcery

Documentation:
- Add a “⚡ LiteLLM Support” section to the README detailing how to select “LiteLLM” as the LLM provider and configure the Base URL for a LiteLLM server

---
## EntelligenceAI PR Summary 
 This PR adds documentation for LiteLLM integration in Clara.
- Updated README.md with a new section on configuring and using LiteLLM as an LLM provider
- No changes to existing content or code 

