### PR TITLE
Add LiteLLM base URL configuration

### DIFF
--- a/src/components/assistant_components/AssistantSettings.tsx
+++ b/src/components/assistant_components/AssistantSettings.tsx
@@ -149,7 +149,7 @@ const AssistantSettings: React.FC<AssistantSettingsProps> = ({
             api_type: (config.api_type as 'ollama' | 'openai' | 'litellm') || 'ollama',
             openai_api_key: config.openai_api_key,
             openai_base_url: config.openai_base_url || 'https://api.openai.com/v1',
-            litellm_base_url: config.litellm_base_url,
+            litellm_base_url: config.litellm_base_url || 'http://localhost:4000',
             n8n_base_url: config.n8n_base_url,
             n8n_api_key: config.n8n_api_key
           };

--- a/src/components/assistant_components/OnboardingModal.tsx
+++ b/src/components/assistant_components/OnboardingModal.tsx
@@ -20,6 +20,7 @@ interface APIConfig {
   api_type: 'ollama' | 'openai' | 'litellm';
   ollama_base_url: string;
   openai_base_url: string;
+  litellm_base_url: string;
   openai_api_key: string;
   comfyui_base_url: string;
   n8n_base_url?: string;
@@ -83,6 +84,7 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
     api_type: 'ollama',
     ollama_base_url: 'http://localhost:11434',
     openai_base_url: 'https://api.openai.com/v1',
+    litellm_base_url: 'http://localhost:4000',
     openai_api_key: '',
     comfyui_base_url: 'http://localhost:8188',
     n8n_base_url: '',
@@ -149,6 +151,8 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
       testConnection();
     } else if (apiConfig.api_type === 'openai' && apiConfig.openai_base_url) {
       testConnection();
+    } else if (apiConfig.api_type === 'litellm' && apiConfig.litellm_base_url) {
+      testConnection();
     }
   }, [apiConfig.api_type]);
 
@@ -163,8 +167,14 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
       if (apiConfig.api_type === 'ollama') {
         baseUrl = apiConfig.ollama_base_url || 'http://localhost:11434';
         clientConfig = { type: 'ollama' };
-      } else {
+      } else if (apiConfig.api_type === 'openai') {
         baseUrl = apiConfig.openai_base_url || 'https://api.openai.com/v1';
+        clientConfig = {
+          type: 'openai',
+          apiKey: apiConfig.openai_api_key
+        };
+      } else {
+        baseUrl = apiConfig.litellm_base_url || 'http://localhost:4000';
         clientConfig = {
           type: 'openai',
           apiKey: apiConfig.openai_api_key
@@ -855,47 +865,53 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
 
                   {/* API Configuration */}
                   <div className="mt-8 space-y-4">
-                    {apiConfig.api_type === 'ollama' ? (
+                  {apiConfig.api_type === 'ollama' && (
+                    <div>
+                      <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
+                        Ollama Base URL
+                      </label>
+                      <input
+                        type="url"
+                        value={apiConfig.ollama_base_url}
+                        onChange={(e) => updateApiConfig({ ollama_base_url: e.target.value })}
+                        className="w-full px-4 py-3 rounded-xl appearance-none bg-white/30 dark:bg-gray-900/30 backdrop-blur-sm focus:bg-white/50 dark:focus:bg-gray-900/50 focus:outline-none focus:ring-2 focus:ring-sakura-500/20 border-0 text-gray-900 dark:text-white shadow-sm transition-all"
+                        placeholder="http://localhost:11434"
+                      />
+                    </div>
+                  )}
+
+                  {(apiConfig.api_type === 'openai' || apiConfig.api_type === 'litellm') && (
+                    <div className="space-y-4">
                       <div>
                         <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
-                          Ollama Base URL
+                          Base URL
                         </label>
                         <input
                           type="url"
-                          value={apiConfig.ollama_base_url}
-                          onChange={(e) => updateApiConfig({ ollama_base_url: e.target.value })}
+                          value={apiConfig.api_type === 'litellm' ? apiConfig.litellm_base_url : apiConfig.openai_base_url}
+                          onChange={(e) =>
+                            apiConfig.api_type === 'litellm'
+                              ? updateApiConfig({ litellm_base_url: e.target.value })
+                              : updateApiConfig({ openai_base_url: e.target.value })
+                          }
                           className="w-full px-4 py-3 rounded-xl appearance-none bg-white/30 dark:bg-gray-900/30 backdrop-blur-sm focus:bg-white/50 dark:focus:bg-gray-900/50 focus:outline-none focus:ring-2 focus:ring-sakura-500/20 border-0 text-gray-900 dark:text-white shadow-sm transition-all"
-                          placeholder="http://localhost:11434"
+                          placeholder={apiConfig.api_type === 'litellm' ? 'http://localhost:4000' : 'https://api.openai.com/v1'}
                         />
                       </div>
-                    ) : (
-                      <div className="space-y-4">
-                        <div>
-                          <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
-                            API Base URL
-                          </label>
-                          <input
-                            type="url"
-                            value={apiConfig.openai_base_url}
-                            onChange={(e) => updateApiConfig({ openai_base_url: e.target.value })}
-                            className="w-full px-4 py-3 rounded-xl appearance-none bg-white/30 dark:bg-gray-900/30 backdrop-blur-sm focus:bg-white/50 dark:focus:bg-gray-900/50 focus:outline-none focus:ring-2 focus:ring-sakura-500/20 border-0 text-gray-900 dark:text-white shadow-sm transition-all"
-                            placeholder="https://api.openai.com/v1"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
-                            API Key
-                          </label>
-                          <input
-                            type="password"
-                            value={apiConfig.openai_api_key}
-                            onChange={(e) => updateApiConfig({ openai_api_key: e.target.value })}
-                            className="w-full px-4 py-3 rounded-xl appearance-none bg-white/30 dark:bg-gray-900/30 backdrop-blur-sm focus:bg-white/50 dark:focus:bg-gray-900/50 focus:outline-none focus:ring-2 focus:ring-sakura-500/20 border-0 text-gray-900 dark:text-white shadow-sm transition-all"
-                            placeholder="sk-..."
-                          />
-                        </div>
+                      <div>
+                        <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-200">
+                          API Key
+                        </label>
+                        <input
+                          type="password"
+                          value={apiConfig.openai_api_key}
+                          onChange={(e) => updateApiConfig({ openai_api_key: e.target.value })}
+                          className="w-full px-4 py-3 rounded-xl appearance-none bg-white/30 dark:bg-gray-900/30 backdrop-blur-sm focus:bg-white/50 dark:focus:bg-gray-900/50 focus:outline-none focus:ring-2 focus:ring-sakura-500/20 border-0 text-gray-900 dark:text-white shadow-sm transition-all"
+                          placeholder="sk-..."
+                        />
                       </div>
-                    )}
+                    </div>
+                  )}
 
                     {/* Connection Test Section */}
                     <div className="mt-6">

--- a/src/components/assistant_components/OnboardingModal.tsx
+++ b/src/components/assistant_components/OnboardingModal.tsx
@@ -148,13 +148,15 @@ const OnboardingModal: React.FC<OnboardingModalProps> = ({
   // Auto-test connection when API type changes
   useEffect(() => {
     if (apiConfig.api_type === 'ollama' && apiConfig.ollama_base_url) {
+  useEffect(() => {
+    if (apiConfig.api_type === 'ollama' && apiConfig.ollama_base_url) {
       testConnection();
     } else if (apiConfig.api_type === 'openai' && apiConfig.openai_base_url) {
       testConnection();
     } else if (apiConfig.api_type === 'litellm' && apiConfig.litellm_base_url) {
       testConnection();
     }
-  }, [apiConfig.api_type]);
+  }, [apiConfig.api_type, apiConfig.ollama_base_url, apiConfig.openai_base_url, apiConfig.litellm_base_url]);
 
   const testConnection = async () => {
     setConnectionStatus('testing');

--- a/src/components/uibuilder_components/ChatPanel.tsx
+++ b/src/components/uibuilder_components/ChatPanel.tsx
@@ -195,6 +195,9 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                 compact={true}
               />
             )}
+            {apiType === 'litellm' && (
+              <span className="ml-2 text-gray-500">{apiConfig.litellm_base_url}</span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/uibuilder_components/ui_builder_libraries/ApiTypeSelector.tsx
+++ b/src/components/uibuilder_components/ui_builder_libraries/ApiTypeSelector.tsx
@@ -25,7 +25,7 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
     ollama_base_url: '',
     openai_base_url: '',
     openai_api_key: '',
-    litellm_base_url: ''
+    litellm_base_url: 'http://localhost:4000'
   });
 
   useEffect(() => {
@@ -39,7 +39,7 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
             ollama_base_url: config.ollama_base_url || '',
             openai_base_url: config.openai_base_url || '',
             openai_api_key: config.openai_api_key || '',
-            litellm_base_url: config.litellm_base_url || ''
+            litellm_base_url: config.litellm_base_url || 'http://localhost:4000'
           });
         }
       } catch (error) {
@@ -91,7 +91,14 @@ const ApiTypeSelector: React.FC<ApiTypeSelectorProps> = ({
         title="API Settings"
       >
         <Settings className="w-3.5 h-3.5" />
-        <span>API: {currentApiType === 'openai' ? 'OpenAI' : currentApiType === 'litellm' ? 'LiteLLM' : 'Ollama'}</span>
+        <span>
+          API:
+          {currentApiType === 'openai'
+            ? 'OpenAI'
+            : currentApiType === 'litellm'
+              ? `LiteLLM (${apiConfig.litellm_base_url || 'http://localhost:4000'})`
+              : 'Ollama'}
+        </span>
       </button>
 
       {isOpen && (


### PR DESCRIPTION
## Summary
- allow configuration of `litellm_base_url` with default `http://localhost:4000`
- load and persist LiteLLM base URL in AssistantSettings and OnboardingModal
- display the configured LiteLLM URL in ApiTypeSelector and ChatPanel

## Testing
- `npm run lint` *(fails: 776 problems)*
- `npm test` *(fails to load src/test/setup.ts)*

## Summary by Sourcery

Enable users to specify and view a custom LiteLLM server endpoint by adding a litellm_base_url setting and integrating it throughout the onboarding and main chat interfaces.

New Features:
- Add support for configuring a LiteLLM base URL with a default of http://localhost:4000

Enhancements:
- Persist and load the LiteLLM base URL in AssistantSettings and OnboardingModal
- Display the configured LiteLLM base URL in ApiTypeSelector and ChatPanel UI components

---
## EntelligenceAI PR Summary 
 This PR adds and standardizes LiteLLM API support and configuration across the UI:
- Defaulted 'litellm_base_url' to 'http://localhost:4000' in settings and API selector
- Extended onboarding modal to support and display LiteLLM configuration
- Displayed LiteLLM base URL in ChatPanel and API selector for user clarity 

