### PR TITLE
Add LiteLLM URL tests

### DIFF
--- a/src/ExecutionEngine.test.ts
+++ b/src/ExecutionEngine.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateExecutionPlan } from './ExecutionEngine';
+import type { Node, Edge } from 'reactflow';
+
+vi.mock('./db', () => ({
+  db: { getAPIConfig: vi.fn().mockResolvedValue(null) }
+}));
+
+describe('generateExecutionPlan', () => {
+  it('uses LiteLLM URL when node config specifies litellm', async () => {
+    const nodes: Node[] = [
+      {
+        id: '1',
+        type: 'baseLlmNode',
+        data: { config: { apiType: 'litellm', litellmUrl: 'http://lite.url', apiKey: 'key' } },
+        position: { x: 0, y: 0 }
+      } as unknown as Node
+    ];
+    const plan = await generateExecutionPlan(nodes, [] as Edge[]);
+    expect(plan.config.type).toBe('litellm');
+    expect(plan.config.baseUrl).toBe('http://lite.url');
+  });
+});

--- a/src/nodeExecutors/BaseLlmExecutor.test.ts
+++ b/src/nodeExecutors/BaseLlmExecutor.test.ts
@@ -16,7 +16,8 @@ vi.mock('../utils/OllamaClient', () => {
 import './BaseLlmExecutor';
 import { OllamaClient as MockOllamaClient } from '../utils/OllamaClient';
 
-const executor = getNodeExecutor('baseLlmNode')!;
+const executor = getNodeExecutor('baseLlmNode');
+if (!executor) throw new Error('BaseLlmNode executor not found');
 
 describe('BaseLlmExecutor with LiteLLM', () => {
   beforeEach(() => {

--- a/src/nodeExecutors/BaseLlmExecutor.test.ts
+++ b/src/nodeExecutors/BaseLlmExecutor.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getNodeExecutor } from './NodeExecutorRegistry';
+
+vi.mock('../utils/OllamaClient', () => {
+  return {
+    OllamaClient: vi.fn().mockImplementation((baseUrl: string) => {
+      return {
+        baseUrl,
+        getConfig: () => ({ baseUrl, type: 'openai', apiKey: '' }),
+        sendChat: vi.fn().mockResolvedValue({ message: { content: 'ok' } })
+      };
+    })
+  };
+});
+
+import './BaseLlmExecutor';
+import { OllamaClient as MockOllamaClient } from '../utils/OllamaClient';
+
+const executor = getNodeExecutor('baseLlmNode')!;
+
+describe('BaseLlmExecutor with LiteLLM', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses LiteLLM base URL when api type is litellm', async () => {
+    const node = { id: '1', data: { config: { model: 'm' } } } as unknown as import('reactflow').Node;
+    const context = {
+      node,
+      inputs: { text: 'hello' },
+      ollamaClient: null,
+      apiConfig: { type: 'litellm', baseUrl: 'https://lite.server', apiKey: 'k' }
+    } as import('./NodeExecutorRegistry').NodeExecutionContext;
+
+    const result = await executor.execute(context);
+    expect(result).toBe('ok');
+    expect(MockOllamaClient).toHaveBeenCalledWith(
+      'https://lite.server',
+      expect.objectContaining({ apiKey: 'k', type: 'openai' })
+    );
+  });
+});

--- a/src/nodeExecutors/ImageTextLlmExecutor.test.ts
+++ b/src/nodeExecutors/ImageTextLlmExecutor.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getNodeExecutor } from './NodeExecutorRegistry';
+
+vi.mock('../utils/OllamaClient', () => {
+  return {
+    OllamaClient: vi.fn().mockImplementation((baseUrl: string) => {
+      return {
+        baseUrl,
+        getConfig: () => ({ baseUrl, type: 'openai', apiKey: '' }),
+        generateWithImages: vi.fn().mockResolvedValue({ response: 'ok' })
+      };
+    })
+  };
+});
+
+import './ImageTextLlmExecutor';
+import { OllamaClient as MockOllamaClient } from '../utils/OllamaClient';
+
+const executor = getNodeExecutor('imageTextLlmNode')!;
+
+describe('ImageTextLlmExecutor with LiteLLM', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses LiteLLM base URL when api type is litellm', async () => {
+    const node = { id: '1', data: { config: { model: 'm' } } } as unknown as import('reactflow').Node;
+    const context = {
+      node,
+      inputs: { src: 'data:image/png;base64,abc' },
+      ollamaClient: null,
+      apiConfig: { type: 'litellm', baseUrl: 'https://lite.server', apiKey: 'k' }
+    } as import('./NodeExecutorRegistry').NodeExecutionContext;
+
+    const result = await executor.execute(context);
+    expect(result).toBe('ok');
+    expect(MockOllamaClient).toHaveBeenCalledWith(
+      'https://lite.server',
+      expect.objectContaining({ apiKey: 'k', type: 'openai' })
+    );
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/utils/AssistantOllamaClient.test.ts
+++ b/src/utils/AssistantOllamaClient.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { AssistantOllamaClient } from './AssistantOllamaClient';
 
-function mockFetch(json: any) {
+function mockFetch(json: unknown) {
   return Promise.resolve({
     ok: true,
     json: () => Promise.resolve(json)
@@ -23,7 +23,7 @@ function createStream(lines: string[]) {
         }
       };
     }
-  } as any;
+  } as ReadableStream<Uint8Array>;
 }
 
 describe('AssistantOllamaClient image generation', () => {
@@ -36,7 +36,7 @@ describe('AssistantOllamaClient image generation', () => {
   });
 
   it('uses OpenAI flow when type is openai', async () => {
-    (fetch as any).mockImplementation(() =>
+  (fetch as unknown as vi.Mock).mockImplementation(() =>
       mockFetch({ choices: [{ message: { content: 'hi' } }], usage: { total_tokens: 5 } })
     );
 
@@ -44,12 +44,12 @@ describe('AssistantOllamaClient image generation', () => {
     const result = await client.generateWithImages('model', 'prompt', ['img']);
 
     expect(fetch).toHaveBeenCalledOnce();
-    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+  expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe('https://api.test/chat/completions');
     expect(result).toEqual({ response: 'hi', eval_count: 5 });
   });
 
   it('uses OpenAI flow when type is litellm', async () => {
-    (fetch as any).mockImplementation(() =>
+  (fetch as unknown as vi.Mock).mockImplementation(() =>
       mockFetch({ choices: [{ message: { content: 'hi' } }], usage: { total_tokens: 5 } })
     );
 
@@ -57,43 +57,55 @@ describe('AssistantOllamaClient image generation', () => {
     const result = await client.generateWithImages('model', 'prompt', ['img']);
 
     expect(fetch).toHaveBeenCalledOnce();
-    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+  expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe('https://api.test/chat/completions');
     expect(result).toEqual({ response: 'hi', eval_count: 5 });
   });
 
   it('streams responses when type is openai', async () => {
-    (fetch as any).mockResolvedValue({
+    (fetch as unknown as vi.Mock).mockResolvedValue({
       ok: true,
       body: createStream(['data: {"choices":[{"delta":{"content":"hello"}}]}\n'])
     });
 
     const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'openai' });
     const gen = client.streamGenerateWithImages('model', 'prompt', ['img']);
-    const chunks: any[] = [];
+    const chunks: Array<{ response: string; eval_count: number }> = [];
     for await (const chunk of gen) {
       chunks.push(chunk);
     }
 
     expect(fetch).toHaveBeenCalledOnce();
-    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe('https://api.test/chat/completions');
     expect(chunks).toEqual([{ response: 'hello', eval_count: 0 }]);
   });
 
   it('streams responses when type is litellm', async () => {
-    (fetch as any).mockResolvedValue({
+    (fetch as unknown as vi.Mock).mockResolvedValue({
       ok: true,
       body: createStream(['data: {"choices":[{"delta":{"content":"hello"}}]}\n'])
     });
 
     const client = new AssistantOllamaClient('https://api.test', { apiKey: 'key', type: 'litellm' });
     const gen = client.streamGenerateWithImages('model', 'prompt', ['img']);
-    const chunks: any[] = [];
+    const chunks: Array<{ response: string; eval_count: number }> = [];
     for await (const chunk of gen) {
       chunks.push(chunk);
     }
 
     expect(fetch).toHaveBeenCalledOnce();
-    expect((fetch as any).mock.calls[0][0]).toBe('https://api.test/chat/completions');
+    expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe('https://api.test/chat/completions');
     expect(chunks).toEqual([{ response: 'hello', eval_count: 0 }]);
   });
+});
+
+it('checks connection using base URL', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  const client = new AssistantOllamaClient('http://test', { type: 'litellm' });
+  const result = await client.checkConnection();
+  expect(fetch).toHaveBeenCalledWith('http://test/api/tags', {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' }
+  });
+  expect(result).toBe(true);
+  vi.restoreAllMocks();
 });


### PR DESCRIPTION
## Summary
- extend AssistantOllamaClient tests
- add BaseLlmExecutor and ImageTextLlmExecutor tests
- test ExecutionEngine LiteLLM plan
- add vitest setup file

## Testing
- `npm test`
- `npx eslint src/nodeExecutors/BaseLlmExecutor.test.ts src/nodeExecutors/ImageTextLlmExecutor.test.ts src/ExecutionEngine.test.ts src/utils/AssistantOllamaClient.test.ts`

## Summary by Sourcery

Add comprehensive tests to validate LiteLLM URL handling across clients and executors

Tests:
- Extend AssistantOllamaClient tests to cover OpenAI and LiteLLM flows, streaming behavior, and connection checks
- Add BaseLlmExecutor test to verify LiteLLM base URL usage
- Add ImageTextLlmExecutor test to verify LiteLLM base URL usage
- Scaffold ExecutionEngine test file
- Add Vitest setup file for test initialization

---
## EntelligenceAI PR Summary 
 This PR adds and improves tests for LiteLLM API configuration and executor logic.
- Introduced new unit tests for execution plan and LLM executors (BaseLlmExecutor, ImageTextLlmExecutor) with LiteLLM
- Standardized test environment with a new setup file for DOM assertions
- Enhanced type safety and added a new test in AssistantOllamaClient.test.ts 

