### PR TITLE
Fix import placement in SynchronizedImageViewer

### DIFF
--- a/src/components/imagegen_components/SynchronizedImageViewer.tsx
+++ b/src/components/imagegen_components/SynchronizedImageViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useCallback } from 'react';
 
 interface SynchronizedImageViewerProps {
   imageUrl: string;
@@ -31,10 +31,7 @@ const SynchronizedImageViewer: React.FC<SynchronizedImageViewerProps> = ({
     };
   }, [syncGroup]);
 
-// At the top of the file, add the import
-import { useCallback } from 'react';
-
-// Add this helper function outside your component
+// Debounce helper used to limit scroll event frequency
 const debounce = (func: Function, wait: number) => {
   let timeout: NodeJS.Timeout;
   return (...args: any[]) => {
@@ -42,8 +39,6 @@ const debounce = (func: Function, wait: number) => {
     timeout = setTimeout(() => func(...args), wait);
   };
 };
-
-// …inside your component…
 
   const handleScroll = useCallback(
     debounce(() => {

--- a/src/components/imagegen_components/SynchronizedImageViewer.tsx
+++ b/src/components/imagegen_components/SynchronizedImageViewer.tsx
@@ -32,7 +32,7 @@ const SynchronizedImageViewer: React.FC<SynchronizedImageViewerProps> = ({
   }, [syncGroup]);
 
 // Debounce helper used to limit scroll event frequency
-const debounce = (func: Function, wait: number) => {
+const debounce = (func: (...args: any[]) => void, wait: number) => {
   let timeout: NodeJS.Timeout;
   return (...args: any[]) => {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- fix misplaced import in `SynchronizedImageViewer`

## Testing
- `npm run lint` *(fails: 699 errors)*
- `npm test`

## Summary by Sourcery

Fix import placement for useCallback in SynchronizedImageViewer and streamline debounce helper comments

Bug Fixes:
- Correct the placement of the useCallback import in the React component

Enhancements:
- Remove redundant import and comments and add a descriptive comment to the debounce helper

---
## EntelligenceAI PR Summary 
 Refactored SynchronizedImageViewer for better code clarity and organization.
- Moved debounce helper outside the component with documentation
- Removed redundant useCallback import and unnecessary comment
- No changes to component logic or functionality 

